### PR TITLE
WebSecurityConfig: add security configs that the h2-console works again

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
@@ -13,6 +13,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
+    http.csrf().disable();
+
+    http.headers()
+        .contentSecurityPolicy(
+            "form-action 'self' http://localhost:8080 screw-your-neighbor-server.herokuapp.com")
+        .and()
+        .frameOptions()
+        .sameOrigin();
+
     http.authorizeRequests().anyRequest().permitAll();
 
     http.exceptionHandling();


### PR DESCRIPTION
Disable csrf, we don't want the hustle to send a CRSF token back
and forth.
Add contentSecurityPolicy (CSP) to allow the h2-console to submit forms to this server under the specified domains.
Add frameOptions to allow frames to display content of the
spring application. Else the browser restricts displaying the h2 console,
which seems to be build with old frame technology.