### PR TITLE
Showcase for spring-data-rest and spring-hateoas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.6'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
     implementation 'org.springdoc:springdoc-openapi-webmvc-core:1.6.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,13 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-hateoas:1.6.6'
     implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.6'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
     implementation 'org.springdoc:springdoc-openapi-webmvc-core:1.6.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
@@ -1,0 +1,54 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.Collection;
+import javax.persistence.*;
+
+@Entity
+public class Game {
+  @Id @GeneratedValue private Long id;
+
+  private String name;
+
+  private GameState gameState = GameState.FINDING_PLAYERS;
+
+  @OneToMany(mappedBy = "game")
+  private Collection<Participation> participations = new ArrayList<>();
+
+  @OneToOne(targetEntity = Game.class)
+  private Game nextGame;
+
+  public Long getId() {
+    return id;
+  }
+
+  @JsonIgnore
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setGameState(GameState gameState) {
+    this.gameState = gameState;
+  }
+
+  public GameState getGameState() {
+    return gameState;
+  }
+
+  public Collection<Participation> getParticipations() {
+    return participations;
+  }
+
+  public Game getNextGame() {
+    return nextGame;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameEmbedProjection.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameEmbedProjection.java
@@ -1,0 +1,19 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import java.util.Collection;
+import org.springframework.data.rest.core.config.Projection;
+
+@Projection(
+    name = "embed",
+    types = {Game.class})
+public interface GameEmbedProjection {
+  Long getId();
+
+  String getName();
+
+  GameState getGameState();
+
+  Collection<ParticipationEmbedProjection> getParticipations();
+
+  Game getNextGame();
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameState.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameState.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+public enum GameState {
+  FINDING_PLAYERS,
+  PLAYING,
+  CLOSED
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Participation.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Participation.java
@@ -1,0 +1,56 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.*;
+
+@Entity
+public class Participation {
+
+  @Id @GeneratedValue private Long id;
+
+  private boolean active;
+
+  private Integer participationNumber;
+
+  @ManyToOne(cascade = {CascadeType.PERSIST})
+  private Game game;
+
+  @ManyToOne private Player player;
+
+  public Long getId() {
+    return id;
+  }
+
+  @JsonIgnore
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public Integer getParticipationNumber() {
+    return participationNumber;
+  }
+
+  public Game getGame() {
+    return game;
+  }
+
+  public void setGame(Game game) {
+    this.game = game;
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public void setPlayer(Player player) {
+    this.player = player;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/ParticipationEmbedProjection.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/ParticipationEmbedProjection.java
@@ -1,0 +1,18 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import org.springframework.data.rest.core.config.Projection;
+
+@Projection(
+    name = "embed",
+    types = {Participation.class})
+public interface ParticipationEmbedProjection {
+  Long getId();
+
+  boolean isActive();
+
+  Integer getParticipationNumber();
+
+  Game getGame();
+
+  Player getPlayer();
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Player.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Player.java
@@ -1,0 +1,32 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Player {
+  @Id @GeneratedValue private Long id;
+
+  private String sessionId;
+
+  private String name;
+
+  public Long getId() {
+    return id;
+  }
+
+  @JsonIgnore
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/SpringRestConfiguration.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/SpringRestConfiguration.java
@@ -1,0 +1,40 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.mapping.ConfigurableHttpMethods;
+import org.springframework.data.rest.core.mapping.ExposureConfiguration;
+import org.springframework.data.rest.core.mapping.ResourceMetadata;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+@Configuration
+public class SpringRestConfiguration {
+  private static final List<Class<?>> ENTITIES_WITH_DELETE = List.of(Player.class);
+
+  @Bean
+  public RepositoryRestConfigurer repositoryRestConfigurer() {
+    return new RepositoryRestConfigurer() {
+      @Override
+      public void configureRepositoryRestConfiguration(
+          RepositoryRestConfiguration config, CorsRegistry cors) {
+        RepositoryRestConfigurer.super.configureRepositoryRestConfiguration(config, cors);
+        ExposureConfiguration exposureConfiguration = config.getExposureConfiguration();
+        exposureConfiguration.withItemExposure(
+            (resourceMetaData, httpMethods) -> disableMethods(resourceMetaData, httpMethods));
+      }
+    };
+  }
+
+  private ConfigurableHttpMethods disableMethods(
+      ResourceMetadata resourceMetadata, ConfigurableHttpMethods httpMethods) {
+    httpMethods = httpMethods.disable(HttpMethod.PUT);
+    if (!ENTITIES_WITH_DELETE.contains(resourceMetadata.getDomainType())) {
+      httpMethods = httpMethods.disable(HttpMethod.DELETE);
+    }
+    return httpMethods;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
@@ -1,0 +1,8 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface GameRepository extends PagingAndSortingRepository<Game, Long> {}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/ParticipationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/ParticipationRepository.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.ParticipationEmbedProjection;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(excerptProjection = ParticipationEmbedProjection.class)
+public interface ParticipationRepository extends PagingAndSortingRepository<Participation, Long> {}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/PlayerRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/PlayerRepository.java
@@ -1,0 +1,13 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface PlayerRepository extends PagingAndSortingRepository<Player, Long> {
+  @SuppressWarnings("unused")
+  Page<Player> findAllByName(String name, Pageable page);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Spring data rest
+spring.data.rest.return-body-on-create=true
+spring.data.rest.return-body-on-update=true

--- a/src/test/resources/http-client.env.json
+++ b/src/test/resources/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "local": {
+    "host": "http://localhost:8080/"
+  },
+  "heroku": {
+    "host": "https://screw-your-neighbor-server.herokuapp.com/"
+  }
+}

--- a/src/test/resources/setup-game.http
+++ b/src/test/resources/setup-game.http
@@ -1,0 +1,38 @@
+POST {{host}}/players
+Content-Type: application/hal+json
+
+{
+  "name": "test"
+}
+
+###
+
+POST {{host}}/games
+Content-Type: application/hal+json
+
+{
+  "name": "test"
+}
+
+
+###
+
+POST {{host}}/participations
+Content-Type: application/hal+json
+
+{
+  "player": "/players/1",
+  "game": "/games/2"
+}
+
+###
+
+GET {{host}}/players
+Accept: application/hal+json
+
+###
+
+GET {{host}}/games?projection=embed
+Accept: application/hal+json
+
+###


### PR DESCRIPTION
Maybe we can save some code writing by using rapid api development with spring-data-rest.

The swagger-ui now looks like this: [Swagger UI.pdf](https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/files/8343611/Swagger.UI.pdf)
