### PR TITLE
WebSecurityConfig: allow all headers to be sent

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
@@ -23,6 +23,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
               corsConfiguration.setAllowedMethods(List.of(CorsConfiguration.ALL));
               corsConfiguration.setAllowedOrigins(
                   List.of("http://localhost:3000", "screw-your-neighbor-react.herokuapp.com"));
+              corsConfiguration.setAllowedHeaders(List.of(CorsConfiguration.ALL));
               return corsConfiguration;
             });
 


### PR DESCRIPTION
The Options request sent the Header "Access-Control-Request-Headers", to
which spring security said: it's not allowed to send this header.
Now this header is allowed.