### PR TITLE
debugging: add org.zalando:logbook-spring-boot-starter to make develo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.zalando:logbook-spring-boot-starter:2.14.0'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # Spring data rest
 spring.data.rest.return-body-on-create=true
 spring.data.rest.return-body-on-update=true
+
+# debugging while writing tests
+logging.level.org.zalando.logbook=${REQUEST_LOGGING_LEVEL:ERROR}


### PR DESCRIPTION
…ping with tests easier

This library logs requests and responses of the spring application.
Activate it by setting the ENV variable REQUEST_LOGGING_LEVEL to TRACE.