### PR TITLE
Player: serialize _links field

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/AuthController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/AuthController.java
@@ -39,9 +39,9 @@ public class AuthController {
             .findById(((Player) principal).getId())
             .orElseThrow(() -> new HttpClientErrorException(HttpStatus.NOT_FOUND));
     EntityModel<Player> entityModel = EntityModel.of(player);
-    Link link =
-        repositoryEntityLinks.forType(Player::getId).linkToItemResource(player).withSelfRel();
-    entityModel.add(link);
+    Link linkToPlayer = repositoryEntityLinks.forType(Player::getId).linkToItemResource(player);
+    entityModel.add(linkToPlayer.withSelfRel());
+    entityModel.add(linkToPlayer.withRel("player"));
     return ResponseEntity.ok(entityModel);
   }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/ParticipationEmbedProjection.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/ParticipationEmbedProjection.java
@@ -12,5 +12,5 @@ public interface ParticipationEmbedProjection {
 
   Integer getParticipationNumber();
 
-  Player getPlayer();
+  PlayerEmbedProjection getPlayer();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/PlayerEmbedProjection.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/PlayerEmbedProjection.java
@@ -1,0 +1,10 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+import org.springframework.data.rest.core.config.Projection;
+
+@Projection(
+    name = "embed",
+    types = {Player.class})
+public interface PlayerEmbedProjection {
+  String getName();
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
@@ -77,7 +77,9 @@ class AuthControllerIntegrationTest {
         .jsonPath("name")
         .isEqualTo(PLAYER_1.getName())
         .jsonPath("_links.self.href")
-        .isEqualTo("%s/players/%s".formatted(createBaseUrl(), createdPlayer.getId()));
+        .isEqualTo("%s/players/%s{?projection}".formatted(createBaseUrl(), createdPlayer.getId()))
+        .jsonPath("_links.player.href")
+        .isEqualTo("%s/players/%s{?projection}".formatted(createBaseUrl(), createdPlayer.getId()));
   }
 
   @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
@@ -104,6 +104,8 @@ public class GameIntegrationTest {
         .isNotEmpty()
         .jsonPath("_embedded.participations[0].player.name")
         .isEqualTo(PLAYER_1.getName())
+        .jsonPath("_embedded.participations[0].player._links.self")
+        .value(notNullValue())
         .jsonPath("_embedded.participations[0].active")
         .isEqualTo(true);
   }


### PR DESCRIPTION
That the frontend can compare the player iri of the participation
with the iri of the player instance representing himself.

Issue: https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/issues/45