### PR TITLE
Bugfix remove public modifiers on junit5 tests

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/H2ConsoleIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/H2ConsoleIntegrationTest.java
@@ -27,7 +27,7 @@ public class H2ConsoleIntegrationTest {
   }
 
   @Test
-  public void h2_console_is_available() {
+  void h2_console_is_available() {
     webTestClient.get().uri(h2ConsolePath).exchange().expectStatus().isFound();
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/OpenApiDocsIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/OpenApiDocsIntegrationTest.java
@@ -14,7 +14,7 @@ public class OpenApiDocsIntegrationTest {
   private WebTestClient webTestClient;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     webTestClient =
         WebTestClient.bindToServer()
             .responseTimeout(Duration.ofMinutes(1))
@@ -23,7 +23,7 @@ public class OpenApiDocsIntegrationTest {
   }
 
   @Test
-  public void swagger_ui_is_available() {
+  void swagger_ui_is_available() {
     webTestClient.get().uri("/swagger-ui.html").exchange().expectStatus().isFound();
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
@@ -6,7 +6,6 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestListener;
 import java.time.Duration;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,6 @@ class AuthControllerIntegrationTest {
   private Player PLAYER_1;
 
   @BeforeEach
-  @AfterEach
   void setup() {
     webTestClient =
         WebTestClient.bindToServer()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/AuthControllerIntegrationTest.java
@@ -32,7 +32,7 @@ class AuthControllerIntegrationTest {
 
   @BeforeEach
   @AfterEach
-  public void setup() {
+  void setup() {
     webTestClient =
         WebTestClient.bindToServer()
             .responseTimeout(Duration.ofMinutes(1))
@@ -44,7 +44,7 @@ class AuthControllerIntegrationTest {
   }
 
   @Test
-  public void return_unauthorized_if_no_session_active() {
+  void return_unauthorized_if_no_session_active() {
     webTestClient.get().uri("/auth/session").exchange().expectStatus().isUnauthorized();
   }
 
@@ -143,7 +143,7 @@ class AuthControllerIntegrationTest {
   }
 
   @Test
-  public void return_unauthorized_if_there_was_no_principal_to_clear() {
+  void return_unauthorized_if_there_was_no_principal_to_clear() {
     webTestClient.post().uri("/auth/logout").exchange().expectStatus().isUnauthorized();
   }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
@@ -44,7 +44,7 @@ public class GameIntegrationTest {
 
   @BeforeEach
   @AfterEach
-  public void setup() {
+  void setup() {
     webTestClient =
         WebTestClient.bindToServer()
             .responseTimeout(Duration.ofMinutes(1))
@@ -55,7 +55,7 @@ public class GameIntegrationTest {
   }
 
   @Test
-  public void create_game_and_return_created_game_by_ID() {
+  void create_game_and_return_created_game_by_ID() {
     HttpHeaders responseHeaders =
         webTestClient
             .post()
@@ -111,7 +111,7 @@ public class GameIntegrationTest {
   }
 
   @Test
-  public void return_found_game_by_ID() {
+  void return_found_game_by_ID() {
 
     GAME_1.setName("My_Game");
     gameRepository.saveAll(List.of(GAME_1));
@@ -133,12 +133,12 @@ public class GameIntegrationTest {
   }
 
   @Test
-  public void return_not_found_game() {
+  void return_not_found_game() {
     webTestClient.get().uri("/games/5").exchange().expectStatus().isNotFound();
   }
 
   @Test
-  public void return_found_all_games() {
+  void return_found_all_games() {
 
     GAME_1.setName("My_first_Game");
     GAME_2.setName("My_second_Game");
@@ -160,7 +160,7 @@ public class GameIntegrationTest {
   }
 
   @Test
-  public void change_gameState_to_playing() {
+  void change_gameState_to_playing() {
     HttpHeaders responseHeaders =
         webTestClient
             .post()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
@@ -12,7 +12,6 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestLi
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +42,6 @@ public class GameIntegrationTest {
   private static final Game GAME_3 = new Game();
 
   @BeforeEach
-  @AfterEach
   void setup() {
     webTestClient =
         WebTestClient.bindToServer()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
@@ -48,7 +48,7 @@ public class ParticipationIntegrationTest {
   }
 
   @Test
-  public void join_existing_game() {
+  void join_existing_game() {
     HttpHeaders responseHeaders =
         webTestClient
             .post()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
@@ -50,7 +50,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void get_all_players_is_empty_without_players() {
+  void get_all_players_is_empty_without_players() {
     webTestClient
         .get()
         .uri(ENDPOINT)
@@ -63,7 +63,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void get_all_players_from_repository() {
+  void get_all_players_from_repository() {
     playerRepository.saveAll(List.of(PLAYER_1));
     playerRepository.saveAll(List.of(PLAYER_2));
 
@@ -79,7 +79,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void get_not_existing_player_fails() {
+  void get_not_existing_player_fails() {
     webTestClient
         .get()
         .uri("%s%s/%s".formatted(createBaseUrl(), ENDPOINT, "1"))
@@ -89,7 +89,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void create_a_player() {
+  void create_a_player() {
     HttpHeaders headers =
         webTestClient
             .post()
@@ -125,7 +125,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void create_a_player_with_too_short_name_fails() {
+  void create_a_player_with_too_short_name_fails() {
     PLAYER_1.setName("a");
     webTestClient
         .post()
@@ -137,7 +137,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void create_2_players_with_the_same_session_fails() {
+  void create_2_players_with_the_same_session_fails() {
     HttpHeaders responseHeaders =
         webTestClient
             .post()
@@ -165,7 +165,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void patch_own_player() {
+  void patch_own_player() {
     HttpHeaders responseHeaders =
         webTestClient
             .post()
@@ -206,7 +206,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void patch_player_when_unauthorized_fails() {
+  void patch_player_when_unauthorized_fails() {
     playerRepository.saveAll(List.of(PLAYER_1));
 
     PLAYER_1.setName("another name");
@@ -223,7 +223,7 @@ public class PlayerIntegrationTest {
   }
 
   @Test
-  public void patch_other_player_fails() {
+  void patch_other_player_fails() {
     playerRepository.saveAll(List.of(PLAYER_2));
 
     HttpHeaders responseHeaders =

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/HelloWorldControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/HelloWorldControllerIntegrationTest.java
@@ -23,7 +23,7 @@ class HelloWorldControllerIntegrationTest {
   }
 
   @Test
-  public void return_200_for_get_root() {
+  void return_200_for_get_root() {
     webTestClient.get().uri("/").exchange().expectStatus().isOk();
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/CardTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/CardTest.java
@@ -12,14 +12,14 @@ class CardTest {
   private CardSuit cardSuit;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     cardRank = CardRank.JACK;
     cardSuit = CardSuit.DIAMOND;
     card_1 = new Card(cardRank, cardSuit);
   }
 
   @Test
-  public void compare_equal_test() {
+  void compare_equal_test() {
     cardRank = CardRank.JACK;
     cardSuit = CardSuit.DIAMOND;
     Card card_2 = new Card(cardRank, cardSuit);
@@ -28,7 +28,7 @@ class CardTest {
   }
 
   @Test
-  public void compare_not_equal_test() {
+  void compare_not_equal_test() {
     cardRank = CardRank.NINE;
     cardSuit = CardSuit.CLUB;
     Card card_2 = new Card(cardRank, cardSuit);
@@ -37,7 +37,7 @@ class CardTest {
   }
 
   @Test
-  public void compare_greater_test() {
+  void compare_greater_test() {
     cardRank = CardRank.EIGHT;
     cardSuit = CardSuit.HEART;
     Card card_2 = new Card(cardRank, cardSuit);
@@ -45,7 +45,7 @@ class CardTest {
   }
 
   @Test
-  public void compare_smaller_greater_test() {
+  void compare_smaller_greater_test() {
     cardRank = CardRank.ACE;
     cardSuit = CardSuit.DIAMOND;
     Card card_2 = new Card(cardRank, cardSuit);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/RoundTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/RoundTest.java
@@ -30,7 +30,7 @@ public class RoundTest {
   Card c_5 = new Card(CardRank.ACE, CardSuit.CLUB);
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     player_1.setName("player_1");
     player_1.setId(1L);
     player_2.setName("player_2");
@@ -61,14 +61,14 @@ public class RoundTest {
   }
 
   @Test
-  public void get_trick_winner_test() {
+  void get_trick_winner_test() {
     round.setCards(cards);
     assertEquals(round.getTrickWinnerIds().size(), 1);
     assertTrue(round.getTrickWinnerIds().contains(player_1.getId()));
   }
 
   @Test
-  public void get_multiple_trick_winner_test() {
+  void get_multiple_trick_winner_test() {
     Player player_4 = new Player();
     player_4.setName("player_4");
     player_4.setId(4L);
@@ -89,7 +89,7 @@ public class RoundTest {
   }
 
   @Test
-  public void get_multiple_same_cards_with_one_trick_winner_test() {
+  void get_multiple_same_cards_with_one_trick_winner_test() {
 
     Player player_4 = new Player();
     player_4.setName("player_4");
@@ -121,7 +121,7 @@ public class RoundTest {
   }
 
   @Test
-  public void empty_cards_list_returns_empty_winner_list() {
+  void empty_cards_list_returns_empty_winner_list() {
     Round emptyRound = new Round();
     assertEquals(emptyRound.getTrickWinnerIds(), List.of());
   }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/StandardCardDeckTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/StandardCardDeckTest.java
@@ -10,12 +10,12 @@ class StandardCardDeckTest {
   private StandardCardDeck standardCardDeck;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     standardCardDeck = new StandardCardDeck();
   }
 
   @Test
-  public void draw_card_not_shuffled_test() {
+  void draw_card_not_shuffled_test() {
     Card card = standardCardDeck.drawCard();
     // StandardCardSet is filled up by iterating over the Enum CardSuit and CardRank, by looking how
     // Suits and Ranks
@@ -29,7 +29,7 @@ class StandardCardDeckTest {
   }
 
   @Test
-  public void shuffle_test() {
+  void shuffle_test() {
     StandardCardDeck previous = this.standardCardDeck;
     standardCardDeck.shuffle();
     Card card = standardCardDeck.drawCard();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/GameValidatorTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/GameValidatorTest.java
@@ -20,7 +20,7 @@ class GameValidatorTest {
   private GameValidator gameValidator;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     OldStateFetcher oldStateFetcher = mock(OldStateFetcher.class);
     when(oldStateFetcher.getPreviousStateOf(notNull(), notNull())).thenReturn(GAME_BEFORE);
 
@@ -32,7 +32,7 @@ class GameValidatorTest {
 
   @ParameterizedTest
   @EnumSource(GameState.class)
-  public void accepts_changing_name(GameState gameState) {
+  void accepts_changing_name(GameState gameState) {
     GAME_BEFORE.setGameState(gameState);
     NEW_GAME.setGameState(gameState);
     NEW_GAME.setName("another name");
@@ -42,7 +42,7 @@ class GameValidatorTest {
 
   @ParameterizedTest
   @CsvSource({"FINDING_PLAYERS, PLAYING", "FINDING_PLAYERS, CLOSED", "PLAYING, CLOSED"})
-  public void accept_valid_state_changes(GameState gameStateBefore, GameState newGameState) {
+  void accept_valid_state_changes(GameState gameStateBefore, GameState newGameState) {
     GAME_BEFORE.setGameState(gameStateBefore);
     NEW_GAME.setGameState(newGameState);
 
@@ -55,8 +55,7 @@ class GameValidatorTest {
     "CLOSED, FINDING_PLAYERS",
     "CLOSED, PLAYING",
   })
-  public void throw_exception_on_invalid_state_changes(
-      GameState gameStateBefore, GameState newGameState) {
+  void throw_exception_on_invalid_state_changes(GameState gameStateBefore, GameState newGameState) {
     GAME_BEFORE.setGameState(gameStateBefore);
     NEW_GAME.setGameState(newGameState);
 


### PR DESCRIPTION
tests: remove public modifiers from junit5 tests

Issue: #114

tests: remove unnecessary @AfterEach

After 5f97b10, this is not necessary anymore.