### PR TITLE
Bugfix issues from "indicate who should play"

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/HandIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/HandIntegrationTest.java
@@ -103,8 +103,12 @@ class HandIntegrationTest {
         .expectStatus()
         .isOk()
         .expectBody()
+        .jsonPath("_embedded.matches[0].hands[0].participation.participationNumber")
+        .isEqualTo(0)
         .jsonPath("_embedded.matches[0].hands[0].turnActive")
         .isEqualTo(true)
+        .jsonPath("_embedded.matches[0].hands[1].participation.participationNumber")
+        .isEqualTo(1)
         .jsonPath("_embedded.matches[0].hands[1].turnActive")
         .isEqualTo(false);
   }
@@ -159,8 +163,12 @@ class HandIntegrationTest {
         .expectStatus()
         .isOk()
         .expectBody()
+        .jsonPath("_embedded.matches[0].hands[0].participation.participationNumber")
+        .isEqualTo(0)
         .jsonPath("_embedded.matches[0].hands[0].turnActive")
         .isEqualTo(false)
+        .jsonPath("_embedded.matches[0].hands[1].participation.participationNumber")
+        .isEqualTo(1)
         .jsonPath("_embedded.matches[0].hands[1].turnActive")
         .isEqualTo(true);
   }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/GameBuilder.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/GameBuilder.java
@@ -85,14 +85,14 @@ public class GameBuilder {
 
         participation = new Participation();
         participation.setPlayer(player);
-
-        participation.setGame(game);
-        game.getParticipations().add(participation);
-
-        if (participationRepository != null) {
-          participationRepository.saveAll(List.of(participation));
-        }
       }
+      participation.setGame(game);
+      game.getParticipations().add(participation);
+
+      if (participationRepository != null) {
+        participationRepository.saveAll(List.of(participation));
+      }
+
       participation.setParticipationNumber(participationNumber++);
       participationMap.put(name, participation);
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/GameBuilder.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/GameBuilder.java
@@ -100,7 +100,6 @@ public class GameBuilder {
     for (MatchBuilder matchBuilder : matches) {
       Match match = matchBuilder.build(participationMap);
       match.setMatchNumber(matchNumber++);
-      match.setMatchState(MatchState.FINISH);
       match.setGame(game);
       game.getMatches().add(match);
     }


### PR DESCRIPTION
From PR #113 

GameBuilder: also attach participation to game when it was not created

closes #126

GameBuilder: remove unnecessary setMatchState in GameBuilder::build

closes #127

HandIntegrationTest: verify that correct hand is active by participationNumber

closes #125