### PR TITLE
Bugfix fix npe for last card of last match

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
@@ -16,7 +16,7 @@ public class CardEventHandler {
   private final ModelFactory modelFactory;
   private final GameRepository gameRepository;
 
-  private final HashMap<Integer, Integer> mapMatchNoToNumberOfCards = new HashMap();
+  private final HashMap<Integer, Integer> mapMatchNoToNumberOfCards = new HashMap<>();
 
   public CardEventHandler(ModelFactory modelFactory, GameRepository gameRepository) {
     this.modelFactory = modelFactory;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
@@ -56,17 +56,19 @@ public class CardEventHandler {
       int numberOfPlayedRounds = match.getRounds().size();
       // no cards remaining in any hand
       if (numberOfPlayedRounds >= numberOfCardsPerPlayer) {
-        Match newMatch = modelFactory.addMatch(game, match.getMatchNumber() + 1);
-        CardDeck cardDeck = new StandardCardDeck();
-        cardDeck.shuffle();
-        int numOfCards = mapMatchNoToNumberOfCards.get(match.getMatchNumber() + 1);
-        for (Participation participation : game.getParticipations()) {
-          Hand hand = modelFactory.addHand(newMatch, participation);
-          for (int j = 0; j < numOfCards; j++) {
-            modelFactory.addCardTo(hand, cardDeck.drawCard());
+        Integer numOfCards = mapMatchNoToNumberOfCards.get(match.getMatchNumber() + 1);
+        if (numOfCards != null) {
+          Match newMatch = modelFactory.addMatch(game, match.getMatchNumber() + 1);
+          CardDeck cardDeck = new StandardCardDeck();
+          cardDeck.shuffle();
+          for (Participation participation : game.getParticipations()) {
+            Hand hand = modelFactory.addHand(newMatch, participation);
+            for (int j = 0; j < numOfCards; j++) {
+              modelFactory.addCardTo(hand, cardDeck.drawCard());
+            }
           }
+          modelFactory.addRound(newMatch, round.getRoundNumber() + 1);
         }
-        modelFactory.addRound(newMatch, round.getRoundNumber() + 1);
       } else {
         modelFactory.addRound(match, round.getRoundNumber() + 1);
       }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
@@ -26,9 +26,7 @@ class CardEventHandlerTest {
 
   @Autowired private RoundRepository roundRepository;
   @Autowired private MatchRepository matchRepository;
-  @Autowired private CardRepository cardRepository;
   @Autowired private GameRepository gameRepository;
-  @Autowired private HandRepository handRepository;
   @Autowired private ParticipationRepository participationRepository;
 
   @Autowired private PlayerRepository playerRepository;
@@ -36,16 +34,9 @@ class CardEventHandlerTest {
   private static final String PLAYER_NAME_1 = "player1";
   private static final String PLAYER_NAME_2 = "player2";
   private static final String PLAYER_NAME_3 = "player3";
-
-  private Participation participation1;
-  private Participation participation2;
-  private Participation participation3;
-  private Game game;
   private Match match;
   private Round round;
   private Card card1;
-  private Card card2;
-  private Card card3;
   @Autowired private CardEventHandler cardEventHandler;
   private GameBuilder.MatchBuilder matchBuilder;
 


### PR DESCRIPTION
CardEventHandlerTest: remove unused fields

CardEventHandler: do not create a match if last card of 9th match is played

This also fixes the NPE for the implicit cast Integer -> int.

Issue: #67

CardEventHandler: reduce cognitive complexity in handleAfterSave

@see https://sonarcloud.io/project/issues?pullRequest=141&issues=AYBcB1nyALjJLndU_FyV&open=AYBcB1nyALjJLndU_FyV&id=sopra-fs22-group-36_screw-your-neighbor-server

It has no a cognitive complexity of 11.

CardEventHandler: fix provide parametrized type for HashMap