### PR TITLE
Feature shift active flag with match number and start round with last winner

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Hand.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Hand.java
@@ -103,8 +103,7 @@ public class Hand {
     List<Round> sortedRounds = match.getSortedRounds();
     int numberOfWonTricks = 0;
     for (Round round : sortedRounds) {
-      ArrayList<Card> highestCards = new ArrayList<>(round.getHighestCards());
-      if (!highestCards.isEmpty() && cards.contains(highestCards.get(highestCards.size() - 1))) {
+      if (hasHandWon(round, this)) {
         numberOfWonTricks++;
       }
     }
@@ -125,5 +124,11 @@ public class Hand {
       return announcedScore * announcedScore;
     }
     return -difference;
+  }
+
+  private static boolean hasHandWon(Round round, Hand hand) {
+    ArrayList<Card> highestCards = new ArrayList<>(round.getHighestCards());
+    return !highestCards.isEmpty()
+        && hand.cards.contains(highestCards.get(highestCards.size() - 1));
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Hand.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Hand.java
@@ -85,8 +85,11 @@ public class Hand {
     if (activeRound.isEmpty()) {
       return false;
     }
+
+    List<Round> sortedRounds = activeMatch.getSortedRounds();
+    List<Hand> handsStartingWithPreviousWinner = rotateHandsByLastWinner(sortedHands, sortedRounds);
     Optional<Hand> firstHandWhichDidNotPlayCard =
-        sortedHands.stream()
+        handsStartingWithPreviousWinner.stream()
             .filter(
                 hand ->
                     hand.getCards().stream()
@@ -124,6 +127,26 @@ public class Hand {
       return announcedScore * announcedScore;
     }
     return -difference;
+  }
+
+  private static List<Hand> rotateHandsByLastWinner(
+      List<Hand> sortedHands, List<Round> sortedRounds) {
+    List<Hand> handsStartingWithPreviousWinner = new ArrayList<>(sortedHands);
+    if (sortedRounds.size() <= 1) {
+      return handsStartingWithPreviousWinner;
+    }
+    List<Round> previousRounds = sortedRounds.subList(0, sortedRounds.size() - 1);
+    Collections.reverse(previousRounds);
+    for (Round round : previousRounds) {
+      Optional<Hand> winnerHand =
+          sortedHands.stream().filter(hand -> hasHandWon(round, hand)).findFirst();
+      if (winnerHand.isPresent()) {
+        int winnerHandIndex = sortedHands.indexOf(winnerHand.get());
+        Collections.rotate(handsStartingWithPreviousWinner, winnerHandIndex);
+        break;
+      }
+    }
+    return handsStartingWithPreviousWinner;
   }
 
   private static boolean hasHandWon(Round round, Hand hand) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Match.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Match.java
@@ -75,9 +75,13 @@ public class Match {
 
   @JsonIgnore
   public List<Hand> getSortedHands() {
-    return hands.stream()
-        .sorted(Comparator.comparingInt(hand -> hand.getParticipation().getParticipationNumber()))
-        .collect(Collectors.toList());
+    List<Hand> sortedHands =
+        hands.stream()
+            .sorted(
+                Comparator.comparingInt(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
+    Collections.rotate(sortedHands, matchNumber - 1);
+    return sortedHands;
   }
 
   public List<Round> getSortedRounds() {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/HandScoreTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/HandScoreTest.java
@@ -10,8 +10,10 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.Participatio
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestListener;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.GameBuilder;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -159,7 +161,10 @@ class HandScoreTest {
     gameRepository.saveAll(List.of(game));
 
     Match match = game.getSortedMatches().get(0);
-    List<Hand> sortedHands = match.getSortedHands();
+    List<Hand> sortedHands =
+        match.getHands().stream()
+            .sorted(Comparator.comparing(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
     Hand handPlayer1 = sortedHands.get(0);
     Hand handPlayer2 = sortedHands.get(1);
     Hand handPlayer3 = sortedHands.get(2);
@@ -199,7 +204,10 @@ class HandScoreTest {
     gameRepository.saveAll(List.of(game));
 
     Match match = game.getSortedMatches().get(0);
-    List<Hand> sortedHands = match.getSortedHands();
+    List<Hand> sortedHands =
+        match.getHands().stream()
+            .sorted(Comparator.comparing(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
     Hand handPlayer1 = sortedHands.get(0);
     Hand handPlayer2 = sortedHands.get(1);
     Hand handPlayer3 = sortedHands.get(2);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/HandTurnActiveTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/HandTurnActiveTest.java
@@ -6,8 +6,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.GameBuilder;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +38,10 @@ class HandTurnActiveTest {
             .build();
 
     Match activeMatch = game.getLastMatch().orElseThrow();
-    List<Hand> hands = activeMatch.getSortedHands();
+    List<Hand> hands =
+        activeMatch.getHands().stream()
+            .sorted(Comparator.comparing(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
     Hand firstHand = hands.get(0);
     Hand secondHand = hands.get(1);
 
@@ -71,7 +76,10 @@ class HandTurnActiveTest {
             .build();
 
     Match activeMatch = game.getLastMatch().orElseThrow();
-    List<Hand> hands = activeMatch.getSortedHands();
+    List<Hand> hands =
+        activeMatch.getHands().stream()
+            .sorted(Comparator.comparing(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
     Hand firstHand = hands.get(0);
     Hand secondHand = hands.get(1);
 
@@ -88,7 +96,7 @@ class HandTurnActiveTest {
   }
 
   @Test
-  void turnActive_also_works_on_second_round_in_second_match() {
+  void in_the_second_match_the_start_player_shifts_by_1() {
     Game game =
         GameBuilder.builder("game1")
             .withParticipation(PLAYER_1)
@@ -111,13 +119,15 @@ class HandTurnActiveTest {
             .withRound()
             .finishRound()
             .withRound()
-            .withPlayedCard(PLAYER_1, ACE_OF_CLUBS)
             .finishRound()
             .finishMatch()
             .build();
 
     Match activeMatch = game.getLastMatch().orElseThrow();
-    List<Hand> hands = activeMatch.getSortedHands();
+    List<Hand> hands =
+        activeMatch.getHands().stream()
+            .sorted(Comparator.comparing(hand -> hand.getParticipation().getParticipationNumber()))
+            .collect(Collectors.toList());
     Hand firstHand = hands.get(0);
     Hand secondHand = hands.get(1);
 


### PR DESCRIPTION
- In the second match, the second player has to start, in the third round the third player etc...
Match: rotate the first player for the matches after the first match

-> don't use the getSortedHands method anymore in the tests, because it's already rotated.

That we follow the rule that the starting player rotates.

- For the second round, the winner of the last round has to start

Hand: start the round with the winner of the previous round

To continue with the stack rule, we have to change the interface of Hand::hasHandWon to Optional<Boolean> because it's possible that no one won the round.


Issue: #58