### PR TITLE
Feature close game on last card

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 @Entity
 public class Game {
@@ -26,6 +28,7 @@ public class Game {
   @OneToMany(
       mappedBy = "game",
       cascade = {CascadeType.ALL})
+  @LazyCollection(LazyCollectionOption.FALSE)
   private Collection<Match> matches = new ArrayList<>();
 
   @OneToOne(targetEntity = Game.class)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
@@ -81,7 +81,9 @@ public class CardEventHandler {
         game.setGameState(GameState.CLOSED);
       }
     }
-    modelFactory.addRound(attachNewRoundTo, newRoundNumber);
+    if (game.getGameState() == GameState.PLAYING) {
+      modelFactory.addRound(attachNewRoundTo, newRoundNumber);
+    }
     gameRepository.saveAll(List.of(game));
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/CardEventHandler.java
@@ -64,17 +64,21 @@ public class CardEventHandler {
     int numberOfCardsPerPlayer = card.getHand().getCards().size();
     int numberOfPlayedRounds = match.getRounds().size();
     Integer numOfCards = mapMatchNoToNumberOfCards.get(newMatchNumber);
-    if (numberOfPlayedRounds >= numberOfCardsPerPlayer && numOfCards != null) {
-      Match newMatch = modelFactory.addMatch(game, newMatchNumber);
-      attachNewRoundTo = newMatch;
-      newRoundNumber = 0;
-      CardDeck cardDeck = new StandardCardDeck();
-      cardDeck.shuffle();
-      for (Participation participation : game.getParticipations()) {
-        Hand hand = modelFactory.addHand(newMatch, participation);
-        for (int j = 0; j < numOfCards; j++) {
-          modelFactory.addCardTo(hand, cardDeck.drawCard());
+    if (numberOfPlayedRounds >= numberOfCardsPerPlayer) {
+      if (numOfCards != null) {
+        Match newMatch = modelFactory.addMatch(game, newMatchNumber);
+        attachNewRoundTo = newMatch;
+        newRoundNumber = 0;
+        CardDeck cardDeck = new StandardCardDeck();
+        cardDeck.shuffle();
+        for (Participation participation : game.getParticipations()) {
+          Hand hand = modelFactory.addHand(newMatch, participation);
+          for (int j = 0; j < numOfCards; j++) {
+            modelFactory.addCardTo(hand, cardDeck.drawCard());
+          }
         }
+      } else {
+        game.setGameState(GameState.CLOSED);
       }
     }
     modelFactory.addRound(attachNewRoundTo, newRoundNumber);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
@@ -164,6 +164,7 @@ class CardEventHandlerTest {
     cardEventHandler.handleAfterSave(card1);
     Collection<Round> savedRounds = roundRepository.findAll();
     Collection<Match> savedMatches = matchRepository.findAll();
+    Game updatedGame = gameRepository.findById(game.getId()).orElseThrow();
 
     assertEquals(3, savedRounds.size());
     assertEquals(2, savedMatches.size());
@@ -171,6 +172,8 @@ class CardEventHandlerTest {
     assertTrue(savedRounds.stream().anyMatch(r -> r.getRoundNumber() == 2));
     assertTrue(savedMatches.stream().anyMatch(m -> m.getMatchNumber() == 1));
     assertTrue(savedMatches.stream().anyMatch(m -> m.getMatchNumber() == 2));
+    assertThat(updatedGame.getMatches(), hasSize(2));
+    assertThat(updatedGame.getGameState(), is(PLAYING));
   }
 
   @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
@@ -1,9 +1,12 @@
 package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.api;
 
+import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState.CLOSED;
+import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState.PLAYING;
 import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.CardValue.*;
 import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.CardValue.JACK_OF_CLUBS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.*;
@@ -171,7 +174,7 @@ class CardEventHandlerTest {
   }
 
   @Test
-  void does_not_create_new_match_when_last_card_played_for_last_match() {
+  void puts_game_to_state_closed_for_last_card_in_last_match() {
     GameBuilder firstFinishedMatch = matchBuilder.finishMatch();
     for (int i = 0; i < 7; i++) {
       firstFinishedMatch.withMatch().finishMatch();
@@ -220,6 +223,62 @@ class CardEventHandlerTest {
 
     cardEventHandler.handleAfterSave(notYetPlayedCard);
 
+    Game updatedGame = gameRepository.findById(game.getId()).orElseThrow();
+    assertThat(updatedGame.getMatches(), hasSize(9));
+    assertThat(updatedGame.getGameState(), is(CLOSED));
+  }
+
+  @Test
+  void does_not_change_gamestate_if_its_not_the_last_card() {
+    GameBuilder firstFinishedMatch = matchBuilder.finishMatch();
+    for (int i = 0; i < 7; i++) {
+      firstFinishedMatch.withMatch().finishMatch();
+    }
+    Game game =
+        firstFinishedMatch
+            .withMatch()
+            .withHandForPlayer(PLAYER_NAME_1)
+            .withCards(ACE_OF_CLUBS, QUEEN_OF_CLUBS)
+            .finishHand()
+            .withHandForPlayer(PLAYER_NAME_2)
+            .withCards(KING_OF_CLUBS, JACK_OF_CLUBS)
+            .finishHand()
+            .withHandForPlayer(PLAYER_NAME_3)
+            .withCards(QUEEN_OF_HEARTS, KING_OF_HEARTS)
+            .finishHand()
+            .withRound()
+            .withPlayedCard(PLAYER_NAME_1, QUEEN_OF_CLUBS)
+            .withPlayedCard(PLAYER_NAME_2, KING_OF_CLUBS)
+            .withPlayedCard(PLAYER_NAME_3, QUEEN_OF_HEARTS)
+            .finishRound()
+            .withRound()
+            .withPlayedCard(PLAYER_NAME_1, ACE_OF_CLUBS)
+            .finishRound()
+            .finishMatch()
+            .build();
+
+    Iterable<Game> savedGames = gameRepository.saveAll(List.of(game));
+
+    match = savedGames.iterator().next().getLastMatch().orElseThrow();
+    lastRound = match.getLastRound().orElseThrow();
+
+    Card notYetPlayedCard =
+        match.getHands().stream()
+            .map(Hand::getCards)
+            .flatMap(Collection::stream)
+            .filter(card -> card.getRound() == null)
+            .findFirst()
+            .orElseThrow();
+
+    notYetPlayedCard.setRound(lastRound);
+    lastRound.getCards().add(notYetPlayedCard);
+
     assertThat(game.getMatches(), hasSize(9));
+
+    cardEventHandler.handleAfterSave(notYetPlayedCard);
+
+    Game updatedGame = gameRepository.findById(game.getId()).orElseThrow();
+    assertThat(updatedGame.getMatches(), hasSize(9));
+    assertThat(updatedGame.getGameState(), is(PLAYING));
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/CardEventHandlerTest.java
@@ -172,23 +172,12 @@ class CardEventHandlerTest {
 
   @Test
   void does_not_create_new_match_when_last_card_played_for_last_match() {
+    GameBuilder firstFinishedMatch = matchBuilder.finishMatch();
+    for (int i = 0; i < 7; i++) {
+      firstFinishedMatch.withMatch().finishMatch();
+    }
     Game game =
-        matchBuilder
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
-            .withMatch()
-            .finishMatch()
+        firstFinishedMatch
             .withMatch()
             .withHandForPlayer(PLAYER_NAME_1)
             .withCards(ACE_OF_CLUBS, QUEEN_OF_CLUBS)


### PR DESCRIPTION
refactor/CardEventHandlerTest: put calls to withMatch/finishMatch in for loop

CardEventHandler: change GameState to closed if last card of last match was played

Use the @LazyCollection annotation on the Game entity that we can eagerly
fetch the matches.

Issue: #154