### PR TITLE
Feature implement create next game (And add ACL Check)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameController.java
@@ -1,0 +1,76 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.controller;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.GameRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.sideeffects.GameEventHandler;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+
+@RestController
+@Transactional
+public class FollowUpGameController {
+  private final GameRepository gameRepository;
+  private final GameEventHandler gameEventHandler;
+
+  private final RepositoryEntityLinks repositoryEntityLinks;
+
+  @Autowired
+  public FollowUpGameController(
+      GameRepository gameRepository,
+      GameEventHandler gameEventHandler,
+      RepositoryEntityLinks repositoryEntityLinks) {
+    this.gameRepository = gameRepository;
+    this.gameEventHandler = gameEventHandler;
+    this.repositoryEntityLinks = repositoryEntityLinks;
+  }
+
+  @PostMapping("/games/{gameId}/nextGame")
+  public ResponseEntity<EntityModel<Game>> createNextGame(@PathVariable Long gameId) {
+    Game previousGame =
+        gameRepository
+            .findById(gameId)
+            .orElseThrow(
+                () ->
+                    new HttpClientErrorException(
+                        HttpStatus.NOT_FOUND,
+                        "The game with the id %s does not exist.".formatted(gameId)));
+
+    if (previousGame.getNextGame() != null) {
+      throw new HttpClientErrorException(
+          HttpStatus.UNPROCESSABLE_ENTITY, "nextGame already exists");
+    }
+
+    Game newGame = new Game();
+    newGame.setGameState(GameState.FINDING_PLAYERS);
+    newGame.setName(previousGame.getName());
+    newGame = gameRepository.save(newGame);
+
+    gameEventHandler.onAfterCreate(newGame);
+
+    previousGame.setNextGame(newGame);
+    try {
+      gameRepository.save(previousGame);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      throw new HttpClientErrorException(
+          HttpStatus.CONFLICT,
+          "Two people tried to update game at the same time. Reload and try again.");
+    }
+
+    EntityModel<Game> entityModel = EntityModel.of(newGame);
+    Link linkToGame = repositoryEntityLinks.forType(Game::getId).linkToItemResource(newGame);
+    entityModel.add(linkToGame.withSelfRel());
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(entityModel);
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/BelongsToGame.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/BelongsToGame.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity;
+
+public interface BelongsToGame {
+  Game getGame();
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
@@ -34,6 +34,11 @@ public class Game {
   @OneToOne(targetEntity = Game.class)
   private Game nextGame;
 
+  @SuppressWarnings("unused")
+  @Version
+  @JsonIgnore
+  private int version;
+
   public Long getId() {
     return id;
   }
@@ -71,6 +76,10 @@ public class Game {
 
   public Collection<Participation> getParticipations() {
     return participations;
+  }
+
+  public void setNextGame(Game nextGame) {
+    this.nextGame = nextGame;
   }
 
   public Game getNextGame() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/Game.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 
 @Entity
-public class Game {
+public class Game implements BelongsToGame {
   @Id @GeneratedValue private Long id;
 
   @NotBlank
@@ -104,5 +104,11 @@ public class Game {
       return Optional.empty();
     }
     return Optional.of(sortedMatches.get(sortedMatches.size() - 1));
+  }
+
+  @JsonIgnore
+  @Override
+  public Game getGame() {
+    return this;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameEmbedProjection.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/entity/GameEmbedProjection.java
@@ -19,5 +19,5 @@ public interface GameEmbedProjection {
 
   Collection<MatchEmbedProjection> getMatches();
 
-  Game getNextGame();
+  GameEmbedProjection getNextGame();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
@@ -3,13 +3,13 @@ package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameEmbedProjection;
 import java.util.List;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @RepositoryRestResource(excerptProjection = GameEmbedProjection.class)
-public interface GameRepository extends PagingAndSortingRepository<Game, Long> {
+public interface GameRepository extends JpaRepository<Game, Long> {
   List<Game> findAllByName(@Param("name") String name);
 
   @Override

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/GameRepository.java
@@ -7,12 +7,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 
 @RepositoryRestResource(excerptProjection = GameEmbedProjection.class)
 public interface GameRepository extends JpaRepository<Game, Long> {
   List<Game> findAllByName(@Param("name") String name);
 
   @Override
-  @PreAuthorize("hasRole('PLAYER')")
-  <S extends Game> S save(S entity);
+  @SuppressWarnings({"SpringElInspection", "ELValidationInspection"})
+  @PreAuthorize("hasRole('PLAYER') && (#game.id == null || belongsToGame(#game))")
+  <S extends Game> S save(@P("game") S entity);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/PlayerRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/repository/PlayerRepository.java
@@ -1,10 +1,12 @@
 package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository;
 
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 
@@ -12,6 +14,9 @@ import org.springframework.security.core.parameters.P;
 public interface PlayerRepository extends PagingAndSortingRepository<Player, Long> {
   @SuppressWarnings("unused")
   Page<Player> findAllByName(String name, Pageable page);
+
+  @RestResource(exported = false)
+  Optional<Player> findByName(String name);
 
   @Override
   @PreAuthorize(

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security;
 
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,6 +14,9 @@ import org.springframework.web.cors.CorsConfiguration;
 @EnableWebSecurity()
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+  @Value("${spring.h2.console.path}")
+  private String h2ConsolePath;
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
@@ -46,6 +50,19 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         });
 
     http.exceptionHandling();
+
+    http.authorizeRequests()
+        .antMatchers(
+            "/",
+            "/auth/**",
+            "/players",
+            "/swagger-ui*",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            h2ConsolePath + "/**")
+        .permitAll()
+        .anyRequest()
+        .authenticated();
 
     http.logout().disable();
   }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
@@ -3,10 +3,12 @@ package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
@@ -47,7 +49,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
           sessionConfig.enableSessionUrlRewriting(false);
         });
 
-    http.exceptionHandling();
+    http.exceptionHandling()
+        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
 
     http.authorizeRequests()
         .antMatchers(

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/WebSecurityConfig.java
@@ -3,7 +3,6 @@ package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -12,7 +11,6 @@ import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
 @EnableWebSecurity()
-@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Value("${spring.h2.console.path}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/CustomMethodSecurityExpressionHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/CustomMethodSecurityExpressionHandler.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.expressions;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.core.Authentication;
+
+public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
+  private final AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+
+  @Override
+  protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
+      Authentication authentication, MethodInvocation invocation) {
+    CustomMethodSecurityExpressionRoot root =
+        new CustomMethodSecurityExpressionRoot(authentication);
+    root.setPermissionEvaluator(getPermissionEvaluator());
+    root.setTrustResolver(this.trustResolver);
+    root.setRoleHierarchy(getRoleHierarchy());
+    return root;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/CustomMethodSecurityExpressionRoot.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/CustomMethodSecurityExpressionRoot.java
@@ -1,0 +1,63 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.expressions;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import java.util.Objects;
+import org.springframework.security.access.expression.SecurityExpressionRoot;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.core.Authentication;
+
+public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
+    implements MethodSecurityExpressionOperations {
+
+  private Object filterObject;
+  private Object returnObject;
+
+  public CustomMethodSecurityExpressionRoot(Authentication authentication) {
+    super(authentication);
+  }
+
+  @SuppressWarnings("unused")
+  public boolean belongsToGame(Game game) {
+    Object principal = getPrincipal();
+    if (!(principal instanceof Player)) {
+      return false;
+    }
+    Player player = (Player) principal;
+    return game.getParticipations().stream()
+        .filter(Participation::isActive)
+        .map(Participation::getPlayer)
+        .anyMatch(participatingPlayer -> isSamePlayer(player, participatingPlayer));
+  }
+
+  private boolean isSamePlayer(Player player, Player participatingPlayer) {
+    return participatingPlayer == player
+        || Objects.equals(participatingPlayer.getId(), player.getId());
+  }
+
+  @Override
+  public Object getFilterObject() {
+    return this.filterObject;
+  }
+
+  @Override
+  public Object getReturnObject() {
+    return this.returnObject;
+  }
+
+  @Override
+  public Object getThis() {
+    return this;
+  }
+
+  @Override
+  public void setFilterObject(Object obj) {
+    this.filterObject = obj;
+  }
+
+  @Override
+  public void setReturnObject(Object obj) {
+    this.returnObject = obj;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/MethodSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/security/expressions/MethodSecurityConfig.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.expressions;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+  @Override
+  protected MethodSecurityExpressionHandler createExpressionHandler() {
+    return new CustomMethodSecurityExpressionHandler();
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/GameEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/GameEventHandler.java
@@ -9,11 +9,9 @@ import javax.transaction.Transactional;
 import org.springframework.data.rest.core.annotation.HandleAfterCreate;
 import org.springframework.data.rest.core.annotation.HandleAfterSave;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Component
 @RepositoryEventHandler
@@ -36,10 +34,6 @@ public class GameEventHandler {
   @HandleAfterCreate
   public void onAfterCreate(Game game) {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    if (!(authentication.getPrincipal() instanceof Player)) {
-      throw new HttpClientErrorException(
-          HttpStatus.UNAUTHORIZED, "Cannot create game when not authorized");
-    }
     game.setVideoChatName(UUID.randomUUID().toString());
 
     Player player = (Player) authentication.getPrincipal();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/PlayerEventHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/sideeffects/PlayerEventHandler.java
@@ -5,7 +5,8 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.Authorities;
 import java.util.List;
 import org.springframework.data.rest.core.annotation.HandleAfterCreate;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
-import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,11 +20,9 @@ public class PlayerEventHandler {
   @HandleAfterCreate
   public void handlePlayerCreated(Player player) {
     SecurityContext context = SecurityContextHolder.getContext();
-    RememberMeAuthenticationToken authentication =
-        new RememberMeAuthenticationToken(
-            player.getId().toString(),
-            player,
-            List.of(new SimpleGrantedAuthority(Authorities.ROLE_PLAYER.name())));
+    AbstractAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            player, player, List.of(new SimpleGrantedAuthority(Authorities.ROLE_PLAYER.name())));
     context.setAuthentication(authentication);
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/OpenApiDocsIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/OpenApiDocsIntegrationTest.java
@@ -26,4 +26,9 @@ class OpenApiDocsIntegrationTest {
   void swagger_ui_is_available() {
     webTestClient.get().uri("/swagger-ui.html").exchange().expectStatus().isFound();
   }
+
+  @Test
+  void swagger_config_is_available() {
+    webTestClient.get().uri("/v3/api-docs/swagger-config").exchange().expectStatus().isOk();
+  }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
@@ -122,8 +122,8 @@ class FollowUpGameControllerApiTest {
   }
 
   @Test
-  void returns_403_for_create_nextGame_when_anonymous() {
-    webTestClient.post().uri("games/42/nextGame").exchange().expectStatus().isForbidden();
+  void returns_401_for_create_nextGame_when_anonymous() {
+    webTestClient.post().uri("games/42/nextGame").exchange().expectStatus().isUnauthorized();
   }
 
   @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
@@ -1,0 +1,122 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.api;
+
+import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.SessionUtil.getSessionIdOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.GameRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.ParticipationRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestListener;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.GameBuilder;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.hateoas.Link;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestExecutionListeners(
+    value = {ClearDBAfterTestListener.class},
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+class FollowUpGameControllerApiTest {
+  private static final ParameterizedTypeReference<Map<String, Object>> GAME_ENTITY_MODEL =
+      new ParameterizedTypeReference<>() {};
+
+  @LocalServerPort private int port;
+
+  private WebTestClient webTestClient;
+
+  @Autowired private PlayerRepository playerRepository;
+  @Autowired private ParticipationRepository participationRepository;
+  @Autowired private GameRepository gameRepository;
+
+  private static final String PLAYER_NAME_1 = "player1";
+  private static final String PLAYER_NAME_2 = "player2";
+
+  private Player PLAYER_1;
+
+  @BeforeEach
+  void setup() {
+    webTestClient =
+        WebTestClient.bindToServer()
+            .responseTimeout(Duration.ofMinutes(1))
+            .baseUrl("http://localhost:" + port)
+            .build();
+
+    PLAYER_1 = new Player();
+    PLAYER_1.setName(PLAYER_NAME_1);
+  }
+
+  @Test
+  void creates_the_follow_up_game() {
+    HttpHeaders responseHeaders =
+        webTestClient
+            .post()
+            .uri("/players")
+            .body(BodyInserters.fromValue(PLAYER_1))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody()
+            .returnResult()
+            .getResponseHeaders();
+
+    String sessionId = getSessionIdOf(responseHeaders);
+    Player createdPlayer = playerRepository.findAll().iterator().next();
+
+    Game game =
+        GameBuilder.builder("game1", gameRepository, participationRepository, playerRepository)
+            .withParticipationWith(createdPlayer)
+            .withParticipation(PLAYER_NAME_2)
+            .withGameState(GameState.CLOSED)
+            .build();
+
+    gameRepository.saveAll(List.of(game));
+
+    String uri = "games/%s/nextGame".formatted(game.getId());
+
+    Map<String, Object> nextGame =
+        webTestClient
+            .post()
+            .uri(uri)
+            .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody(GAME_ENTITY_MODEL)
+            .returnResult()
+            .getResponseBody();
+
+    assertThat(nextGame, is(notNullValue()));
+    assertThat(nextGame.get("_links"), notNullValue());
+
+    @SuppressWarnings("unchecked")
+    Map<String, Map<String, String>> links =
+        (Map<String, Map<String, String>>) nextGame.get("_links");
+
+    URI nextGameUri =
+        Link.of(links.get("self").get("href")).getTemplate().expand(Map.of("projection", ""));
+
+    webTestClient
+        .get()
+        .uri(nextGameUri)
+        .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/FollowUpGameControllerApiTest.java
@@ -119,4 +119,9 @@ class FollowUpGameControllerApiTest {
         .expectStatus()
         .isOk();
   }
+
+  @Test
+  void returns_403_for_create_nextGame_when_anonymous() {
+    webTestClient.post().uri("games/42/nextGame").exchange().expectStatus().isForbidden();
+  }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/GameIntegrationTest.java
@@ -92,6 +92,7 @@ class GameIntegrationTest {
     webTestClient
         .get()
         .uri(uri)
+        .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
         .exchange()
         .expectStatus()
         .isOk()
@@ -112,6 +113,19 @@ class GameIntegrationTest {
 
   @Test
   void return_found_game_by_ID() {
+    HttpHeaders responseHeaders =
+        webTestClient
+            .post()
+            .uri("/players")
+            .body(BodyInserters.fromValue(PLAYER_1))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody()
+            .returnResult()
+            .getResponseHeaders();
+
+    String sessionId = getSessionIdOf(responseHeaders);
 
     GAME_1.setName("My_Game");
     gameRepository.saveAll(List.of(GAME_1));
@@ -122,6 +136,7 @@ class GameIntegrationTest {
     webTestClient
         .get()
         .uri(uri)
+        .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
         .exchange()
         .expectStatus()
         .isOk()
@@ -134,7 +149,27 @@ class GameIntegrationTest {
 
   @Test
   void return_not_found_game() {
-    webTestClient.get().uri("/games/5").exchange().expectStatus().isNotFound();
+    HttpHeaders responseHeaders =
+        webTestClient
+            .post()
+            .uri("/players")
+            .body(BodyInserters.fromValue(PLAYER_1))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody()
+            .returnResult()
+            .getResponseHeaders();
+
+    String sessionId = getSessionIdOf(responseHeaders);
+
+    webTestClient
+        .get()
+        .uri("/games/5")
+        .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
+        .exchange()
+        .expectStatus()
+        .isNotFound();
   }
 
   @Test
@@ -147,10 +182,25 @@ class GameIntegrationTest {
     var gamesList = List.of(GAME_1, GAME_2, GAME_3);
     gameRepository.saveAll(gamesList);
 
+    HttpHeaders responseHeaders =
+        webTestClient
+            .post()
+            .uri("/players")
+            .body(BodyInserters.fromValue(PLAYER_1))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody()
+            .returnResult()
+            .getResponseHeaders();
+
+    String sessionId = getSessionIdOf(responseHeaders);
+
     var games =
         webTestClient
             .get()
             .uri("/games")
+            .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
             .exchange()
             .expectStatus()
             .isOk()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
@@ -80,9 +80,24 @@ class PlayerIntegrationTest {
 
   @Test
   void get_not_existing_player_fails() {
+    HttpHeaders responseHeaders =
+        webTestClient
+            .post()
+            .uri("/players")
+            .body(BodyInserters.fromValue(PLAYER_1))
+            .exchange()
+            .expectStatus()
+            .isCreated()
+            .expectBody()
+            .returnResult()
+            .getResponseHeaders();
+
+    String sessionId = getSessionIdOf(responseHeaders);
+
     webTestClient
         .get()
         .uri("%s%s/%s".formatted(createBaseUrl(), ENDPOINT, "1"))
+        .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
         .exchange()
         .expectStatus()
         .isNotFound();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/PlayerIntegrationTest.java
@@ -234,7 +234,7 @@ class PlayerIntegrationTest {
         .body(BodyInserters.fromValue(PLAYER_1))
         .exchange()
         .expectStatus()
-        .isForbidden();
+        .isUnauthorized();
   }
 
   @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameControllerIntegrationTest.java
@@ -50,7 +50,7 @@ class FollowUpGameControllerIntegrationTest {
         Optional.ofNullable(context.getAuthentication())
             .map(Authentication::getPrincipal)
             .orElse(null);
-    if (!(principal instanceof Player)) {
+    if (!(principal instanceof Player) || !PLAYER_NAME_1.equals(((Player) principal).getName())) {
       Player player = new Player();
       player.setName(PLAYER_NAME_1);
       playerRepository.saveAll(List.of(player));
@@ -99,6 +99,12 @@ class FollowUpGameControllerIntegrationTest {
   @Test
   @WithAnonymousUser
   void throws_if_not_authenticated() {
+    assertThrows(AccessDeniedException.class, () -> followUpGameController.createNextGame(gameId));
+  }
+
+  @Test
+  @WithPersistedPlayer(playerName = "another player")
+  void throws_if_player_is_not_part_of_the_game() {
     assertThrows(AccessDeniedException.class, () -> followUpGameController.createNextGame(gameId));
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameControllerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/controller/FollowUpGameControllerIntegrationTest.java
@@ -1,0 +1,104 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.HttpStatus.*;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.GameRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.ParticipationRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestListener;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.GameBuilder;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.WithPersistedPlayer;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.web.client.HttpClientErrorException;
+
+@SpringBootTest
+@TestExecutionListeners(
+    value = {ClearDBAfterTestListener.class},
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+class FollowUpGameControllerIntegrationTest {
+
+  @Autowired private FollowUpGameController followUpGameController;
+  @Autowired private PlayerRepository playerRepository;
+  @Autowired private ParticipationRepository participationRepository;
+  @Autowired private GameRepository gameRepository;
+  private static final String PLAYER_NAME_1 = "player1";
+  private static final String PLAYER_NAME_2 = "player2";
+
+  private Long gameId;
+
+  @BeforeEach
+  void setup() {
+    SecurityContext context = SecurityContextHolder.getContext();
+    Object principal =
+        Optional.ofNullable(context.getAuthentication())
+            .map(Authentication::getPrincipal)
+            .orElse(null);
+    if (!(principal instanceof Player)) {
+      Player player = new Player();
+      player.setName(PLAYER_NAME_1);
+      playerRepository.saveAll(List.of(player));
+      principal = player;
+    }
+    Player player1 = (Player) principal;
+
+    Game game =
+        GameBuilder.builder("game1", gameRepository, participationRepository, playerRepository)
+            .withParticipationWith(player1)
+            .withParticipation(PLAYER_NAME_2)
+            .withGameState(GameState.CLOSED)
+            .build();
+
+    gameRepository.saveAll(List.of(game));
+    gameId = game.getId();
+  }
+
+  @Test
+  @WithPersistedPlayer(playerName = PLAYER_NAME_1)
+  void throws_notFound_if_game_with_id_does_not_exist() {
+    try {
+      followUpGameController.createNextGame(gameId + 1);
+      fail("no exception thrown");
+    } catch (HttpClientErrorException e) {
+      assertThat(e.getStatusCode(), is(NOT_FOUND));
+    }
+
+    assertThat(gameRepository.findAll(), hasSize(1));
+  }
+
+  @Test
+  @WithPersistedPlayer(playerName = PLAYER_NAME_1)
+  void throws_error_if_nextGame_already_exists() {
+    followUpGameController.createNextGame(gameId);
+
+    try {
+      followUpGameController.createNextGame(gameId);
+      fail("no exception thrown");
+    } catch (HttpClientErrorException e) {
+      assertThat(e.getStatusCode(), is(UNPROCESSABLE_ENTITY));
+    }
+    assertThat(gameRepository.findAll(), hasSize(2));
+  }
+
+  @Test
+  @WithAnonymousUser
+  void throws_if_not_authenticated() {
+    assertThrows(AccessDeniedException.class, () -> followUpGameController.createNextGame(gameId));
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayer.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayer.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithPersistedPlayerSecurityContextFactory.class)
+public @interface WithPersistedPlayer {
+  String playerName() default "test";
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayerSecurityContextFactory.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayerSecurityContextFactory.java
@@ -1,0 +1,38 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.Authorities;
+import java.util.List;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithPersistedPlayerSecurityContextFactory
+    implements WithSecurityContextFactory<WithPersistedPlayer> {
+  private final PlayerRepository playerRepository;
+
+  public WithPersistedPlayerSecurityContextFactory(PlayerRepository playerRepository) {
+    this.playerRepository = playerRepository;
+  }
+
+  @Override
+  public SecurityContext createSecurityContext(WithPersistedPlayer withPersistedPlayer) {
+    Player newPlayer = new Player();
+    Player player = playerRepository.findByName(withPersistedPlayer.playerName()).orElse(newPlayer);
+    player.setName(withPersistedPlayer.playerName());
+    playerRepository.saveAll(List.of(player));
+
+    SecurityContext context = SecurityContextHolder.getContext();
+    RememberMeAuthenticationToken authentication =
+        new RememberMeAuthenticationToken(
+            newPlayer.getId().toString(),
+            newPlayer,
+            List.of(new SimpleGrantedAuthority(Authorities.ROLE_PLAYER.name())));
+    context.setAuthentication(authentication);
+
+    return context;
+  }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayerSecurityContextFactory.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/util/WithPersistedPlayerSecurityContextFactory.java
@@ -4,7 +4,8 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.PlayerRepository;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.security.Authorities;
 import java.util.List;
-import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -26,9 +27,9 @@ public class WithPersistedPlayerSecurityContextFactory
     playerRepository.saveAll(List.of(player));
 
     SecurityContext context = SecurityContextHolder.getContext();
-    RememberMeAuthenticationToken authentication =
-        new RememberMeAuthenticationToken(
-            newPlayer.getId().toString(),
+    AbstractAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            newPlayer,
             newPlayer,
             List.of(new SimpleGrantedAuthority(Authorities.ROLE_PLAYER.name())));
     context.setAuthentication(authentication);


### PR DESCRIPTION
Game: implement creation of follow up game with FollowUpGameController

api: require authentication for most requests

Except "/", "/auth/**", "/players", "/swagger-ui*", "/swagger-ui/**", h2ConsolePath + "/**"

GameRepository: only allow members of a game to change the game

According to the tutorial on:
https://www.baeldung.com/spring-security-create-new-custom-security-expression

Show it with the test in FollowUpGameControllerIntegrationTest that
a player who is not part of the game cannot create the next game.

The idea is that you can implement the BelongsToGame interface on every entity,
and then use belongsToGame(#entity.game) in the @PreAuthorize expression.

FollowUpGameControllerApiTest: show that when belongsToGame is false a 403 is returned

Because i want to later return 401 when there is no authentication at all.

WebSecurity: respond to missing authentication with 401 instead of 403

Issue: #154
Issue: #140
