### PR TITLE
Feature validation: Participation not allow while game is not in right state

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
@@ -15,12 +15,14 @@ public class ParticipationValidator {
   @SuppressWarnings("unused")
   @HandleBeforeCreate
   public void onUpdateParticipation(Participation participation) {
-    GameState participationGameState = participation.getGame().getGameState();
+    if (participation.getGame() != null) {
+      GameState participationGameState = participation.getGame().getGameState();
 
-    if (participationGameState != GameState.FINDING_PLAYERS) {
-      throw new HttpClientErrorException(
-          HttpStatus.UNPROCESSABLE_ENTITY,
-          "Player can't join a game in game state %s".formatted(participationGameState));
+      if (participationGameState != GameState.FINDING_PLAYERS) {
+        throw new HttpClientErrorException(
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            "Player can't join a game in game state %s".formatted(participationGameState));
+      }
     }
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
@@ -1,0 +1,26 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.validation;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
+import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Component
+@RepositoryEventHandler
+public class ParticipationValidator {
+
+  @SuppressWarnings("unused")
+  @HandleBeforeCreate
+  public void onUpdateParticipation(Participation participation) {
+    GameState participationGameState = participation.getGame().getGameState();
+
+    if (participationGameState != GameState.FINDING_PLAYERS) {
+      throw new HttpClientErrorException(
+          HttpStatus.UNPROCESSABLE_ENTITY,
+          "Player can't join a game in game state %s".formatted(participationGameState));
+    }
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidator.java
@@ -15,14 +15,12 @@ public class ParticipationValidator {
   @SuppressWarnings("unused")
   @HandleBeforeCreate
   public void onUpdateParticipation(Participation participation) {
-    if (participation.getGame() != null) {
-      GameState participationGameState = participation.getGame().getGameState();
+    GameState participationGameState = participation.getGame().getGameState();
 
-      if (participationGameState != GameState.FINDING_PLAYERS) {
-        throw new HttpClientErrorException(
-            HttpStatus.UNPROCESSABLE_ENTITY,
-            "Player can't join a game in game state %s".formatted(participationGameState));
-      }
+    if (participationGameState != GameState.FINDING_PLAYERS) {
+      throw new HttpClientErrorException(
+          HttpStatus.UNPROCESSABLE_ENTITY,
+          "Player can't join a game in game state %s".formatted(participationGameState));
     }
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
@@ -15,6 +15,7 @@ import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.ClearDBAfterTestLi
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.GameBuilder;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,7 +86,13 @@ class ParticipationIntegrationTest {
         .post()
         .uri("/participations")
         .header(HttpHeaders.COOKIE, "JSESSIONID=%s".formatted(sessionId))
-        .body(BodyInserters.fromValue(participation))
+        .body(
+            BodyInserters.fromValue(
+                Map.of(
+                    "game",
+                    "/games/%s".formatted(GAME_1.getId()),
+                    "player",
+                    "/players/%s".formatted(player.getId()))))
         .exchange()
         .expectStatus()
         .isCreated()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
@@ -6,6 +6,7 @@ import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.SessionUtil
 import static org.hamcrest.Matchers.*;
 
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.GameRepository;
@@ -17,12 +18,14 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.reactive.function.BodyInserters;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -74,12 +77,18 @@ class ParticipationIntegrationTest {
 
     Player player = playerRepository.findAll().iterator().next();
 
-    GAME_1.setName("game_1");
-    gameRepository.saveAll(List.of(GAME_1));
+    Game game =
+            GameBuilder.builder("test", gameRepository, participationRepository, playerRepository)
+                    .withGameState(GameState.FINDING_PLAYERS)
+                    .withParticipation(PLAYER_NAME_2)
+                    .build();
+    gameRepository.saveAll(List.of(game));
+    GameState test = game.getGameState();
 
     Participation participation = new Participation();
-    participation.setGame(GAME_1);
+    participation.setGame(game);
     participation.setPlayer(player);
+    participation.setActive(true);
 
     webTestClient
         .post()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/api/ParticipationIntegrationTest.java
@@ -6,7 +6,6 @@ import static ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.util.SessionUtil
 import static org.hamcrest.Matchers.*;
 
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
-import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Player;
 import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.repository.GameRepository;
@@ -18,14 +17,12 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.reactive.function.BodyInserters;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -77,18 +74,12 @@ class ParticipationIntegrationTest {
 
     Player player = playerRepository.findAll().iterator().next();
 
-    Game game =
-            GameBuilder.builder("test", gameRepository, participationRepository, playerRepository)
-                    .withGameState(GameState.FINDING_PLAYERS)
-                    .withParticipation(PLAYER_NAME_2)
-                    .build();
-    gameRepository.saveAll(List.of(game));
-    GameState test = game.getGameState();
+    GAME_1.setName("game_1");
+    gameRepository.saveAll(List.of(GAME_1));
 
     Participation participation = new Participation();
-    participation.setGame(game);
+    participation.setGame(GAME_1);
     participation.setPlayer(player);
-    participation.setActive(true);
 
     webTestClient
         .post()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidatorTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/screwyourneighborserver/validation/ParticipationValidatorTest.java
@@ -1,0 +1,85 @@
+package ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.GameState;
+import ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.web.client.HttpClientErrorException;
+
+class ParticipationValidatorTest {
+  private static final Game GAME_FINDING_PLAYERS = new Game();
+  private static final Game GAME_ILLEGAL_STATE = new Game();
+
+  private static final Participation PARTICIPATION_1 = new Participation();
+  private static final Participation PARTICIPATION_2 = new Participation();
+  private static final Participation PARTICIPATION_3 = new Participation();
+  private ParticipationValidator participationValidator;
+
+  @BeforeEach
+  void setup() {
+    GAME_FINDING_PLAYERS.setGameState(GameState.FINDING_PLAYERS);
+    GAME_ILLEGAL_STATE.setGameState(GameState.PLAYING);
+
+    GAME_FINDING_PLAYERS.setId(1L);
+    GAME_ILLEGAL_STATE.setId(2L);
+
+    PARTICIPATION_1.setId(1L);
+    PARTICIPATION_2.setId(2L);
+    PARTICIPATION_3.setId(3L);
+
+    participationValidator = new ParticipationValidator();
+  }
+
+  @Test
+  void player_join_game_valid_game_state() {
+    PARTICIPATION_1.setParticipationNumber(0);
+    PARTICIPATION_2.setParticipationNumber(1);
+    PARTICIPATION_3.setParticipationNumber(3);
+
+    PARTICIPATION_1.setGame(GAME_FINDING_PLAYERS);
+    PARTICIPATION_2.setGame(GAME_FINDING_PLAYERS);
+    PARTICIPATION_3.setGame(GAME_FINDING_PLAYERS);
+
+    assertDoesNotThrow(() -> participationValidator.onUpdateParticipation(PARTICIPATION_1));
+    assertDoesNotThrow(() -> participationValidator.onUpdateParticipation(PARTICIPATION_2));
+    assertDoesNotThrow(() -> participationValidator.onUpdateParticipation(PARTICIPATION_3));
+  }
+
+  @Test
+  void player_join_game_valid_game_state_then_start_game_after_one_illegal_join() {
+    PARTICIPATION_1.setParticipationNumber(0);
+    PARTICIPATION_2.setParticipationNumber(1);
+    PARTICIPATION_3.setParticipationNumber(3);
+
+    PARTICIPATION_1.setGame(GAME_FINDING_PLAYERS);
+    PARTICIPATION_2.setGame(GAME_FINDING_PLAYERS);
+
+    assertDoesNotThrow(() -> participationValidator.onUpdateParticipation(PARTICIPATION_1));
+    assertDoesNotThrow(() -> participationValidator.onUpdateParticipation(PARTICIPATION_2));
+
+    GAME_FINDING_PLAYERS.setGameState(GameState.PLAYING);
+    PARTICIPATION_3.setGame(GAME_FINDING_PLAYERS);
+    assertThrows(
+        HttpClientErrorException.class,
+        () -> participationValidator.onUpdateParticipation(PARTICIPATION_3));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"CLOSED", "PLAYING"})
+  void player_join_game_invalid_game_state(GameState invalidGameState) {
+    GAME_ILLEGAL_STATE.setGameState(invalidGameState);
+
+    PARTICIPATION_1.setParticipationNumber(0);
+    PARTICIPATION_1.setGame(GAME_ILLEGAL_STATE);
+
+    assertThrows(
+        HttpClientErrorException.class,
+        () -> participationValidator.onUpdateParticipation(PARTICIPATION_1));
+  }
+}


### PR DESCRIPTION
## Issue: 
#165 

I've trouble with the integration test.
## Error message:
{"cause":null,"message":"Cannot invoke \"ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Game.getGameState()\" 
because the return value of \"ch.uzh.ifi.hase.soprafs22.screwyourneighborserver.entity.Participation.getGame()\" is null"}

## Comments:
- I don't know why: because the game has all information...could please anybody help? 
- And my the error code could also be 409?! What you think. 